### PR TITLE
feat: remove subscription audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,12 @@ Terraform module which creates an Azure Log Analytics workspace.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.0.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.0.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
 
@@ -27,10 +25,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_log_analytics_workspace.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
-| [azurerm_monitor_diagnostic_setting.subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
-| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-data "azurerm_subscription" "current" {}
-
 resource "azurerm_log_analytics_workspace" "this" {
   name                = var.workspace_name
   resource_group_name = var.resource_group_name
@@ -33,55 +31,5 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       days    = 0
       enabled = false
     }
-  }
-}
-
-resource "random_id" "this" {
-  byte_length = 8
-}
-
-resource "azurerm_monitor_diagnostic_setting" "subscription" {
-  name                       = "audit-logs-${random_id.this.hex}"
-  target_resource_id         = data.azurerm_subscription.current.id
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
-
-  log {
-    category = "Administrative"
-    enabled  = true
-  }
-
-  log {
-    category = "ServiceHealth"
-    enabled  = false
-  }
-
-  log {
-    category = "ResourceHealth"
-    enabled  = false
-  }
-
-  log {
-    category = "Alert"
-    enabled  = false
-  }
-
-  log {
-    category = "Autoscale"
-    enabled  = true
-  }
-
-  log {
-    category = "Recommendation"
-    enabled  = false
-  }
-
-  log {
-    category = "Security"
-    enabled  = true
-  }
-
-  log {
-    category = "Policy"
-    enabled  = true
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,5 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.0.0"
     }
-
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.0.0"
-    }
   }
 }


### PR DESCRIPTION
Remove diagnostic setting for exporting subscription audit logs, to remove required permissions at subscription scope.