### PR TITLE
feat: output workspace name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "workspace_name" {
+  description = "The name of this Log Analytics workspace."
+  value       = azurerm_log_analytics_workspace.this.name
+}
+
 output "workspace_id" {
   description = "The ID of this Log Analytics workspace."
   value       = azurerm_log_analytics_workspace.this.id


### PR DESCRIPTION
Added output `workspace_name` to allow resources like `azurerm_log_analytics_solution` to retrieve this value. 