### PR TITLE
fix: correct minimum required Azure provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.39.0"
+      version = ">= 3.41.0"
     }
   }
 }


### PR DESCRIPTION
Support for `local_authentication_disabled` added in version 3.41