### PR TITLE
feat: send diagnostic to separate workspace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_log_analytics_workspace" "this" {
 resource "azurerm_monitor_diagnostic_setting" "this" {
   name                       = "audit-logs"
   target_resource_id         = azurerm_log_analytics_workspace.this.id
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
+  log_analytics_workspace_id = coalesce(var.log_analytics_workspace_id, azurerm_log_analytics_workspace.this.id)
 
   # Ref: https://registry.terraform.io/providers/hashicorp/azurerm/3.65.0/docs/resources/monitor_diagnostic_setting#log_analytics_destination_type
   log_analytics_destination_type = null

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,13 @@ variable "local_authentication_disabled" {
   default     = true
 }
 
+variable "log_analytics_workspace_id" {
+  description = "The ID of a Log Analytics workspace to send diagnostics to. If value is null, diagnostics will be sent to this Log Analytics workspace."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
 variable "retention_in_days" {
   description = "The number of days that logs should be retained."
   type        = number


### PR DESCRIPTION
By default, this module sends diagnostics for the created Log Analytics workspace to itself.

Add variable `log_analytics_workspace_id` to allow sendings diagnostics to a separate workspace.