### PR TITLE
fix: argument `local_authentication_disabled` has been deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 resource "azurerm_log_analytics_workspace" "this" {
-  name                          = var.workspace_name
-  resource_group_name           = var.resource_group_name
-  location                      = var.location
-  local_authentication_disabled = var.local_authentication_disabled
-  sku                           = "PerGB2018"
-  retention_in_days             = var.retention_in_days
+  name                         = var.workspace_name
+  resource_group_name          = var.resource_group_name
+  location                     = var.location
+  local_authentication_enabled = !var.local_authentication_disabled
+  sku                          = "PerGB2018"
+  retention_in_days            = var.retention_in_days
 
   tags = var.tags
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,8 +4,8 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      # Version 4.31.0 is required to use the "enabled_metric" argument for the "azurerm_monitor_diagnostic_setting" resource.
-      version = ">= 4.31.0"
+      # Version 4.35.0 is required to use the "local_authentication_enabled" argument for the "azurerm_log_analytics_workspace" resource.
+      version = ">= 4.35.0"
     }
   }
 }


### PR DESCRIPTION
- Replace argument `local_authentication_disabled` with `local_authentication_enabled`.
- Bump minimum allowed Azure provider version. Version 4.35.0 is required to use the `local_authentication_enabled` argument (<https://github.com/hashicorp/terraform-provider-azurerm/commit/626a3b8c3b3f26ecf75dfeb66074b5e0c1c55a82>).